### PR TITLE
Fix: get rid of deprecated clock package

### DIFF
--- a/syringe_pump/device.py
+++ b/syringe_pump/device.py
@@ -18,7 +18,7 @@ from pdb import pm
 
 from numpy import nan, mean, std, nanstd, asfarray, asarray, hstack, array, concatenate, delete, round, vstack, hstack, zeros, transpose, split, unique, nonzero, take, savetxt, min, max
 
-from time import time, sleep, clock
+from time import time, sleep
 import sys
 import struct
 from pdb import pm


### PR DESCRIPTION
- remove deprecated clock package in the syringe pump device file ( wasn't being used in the file as well ) 
- fixes: #9 