### PR TITLE
Check for empty bytes instead of empty string for queries

### DIFF
--- a/syringe_pump/device.py
+++ b/syringe_pump/device.py
@@ -828,7 +828,7 @@ class Device(object):
         >>> device.flow(position = 25, speed = 0.1)
         """
         self.abort()
-        if self.valve is not 'o':
+        if self.valve != 'o':
             self.set_valve('o')
         if speed <= self.flow_speed_high_limit:
             reply = self.move_abs(position = position, speed = speed)

--- a/syringe_pump/driver.py
+++ b/syringe_pump/driver.py
@@ -240,7 +240,7 @@ class Driver(object):
         else:
             reply = None
         #parsing reply
-        if reply is not None and reply is not '':
+        if reply is not None and reply is not b'':
             #the positinonal reply \xff/0`0.000\x03\r\n is sandwiched between '\x03\r\n' and '\xff/0'
             error_code = reply.split(b'\x03\r\n')[0].split(b'\xff/0')[1][0:1]
             value = reply.split(b'\x03\r\n')[0].split(b'\xff/0')[1][1:]

--- a/syringe_pump/driver.py
+++ b/syringe_pump/driver.py
@@ -240,7 +240,7 @@ class Driver(object):
         else:
             reply = None
         #parsing reply
-        if reply is not None and reply is not b'':
+        if reply is not None and reply != b'':
             #the positinonal reply \xff/0`0.000\x03\r\n is sandwiched between '\x03\r\n' and '\xff/0'
             error_code = reply.split(b'\x03\r\n')[0].split(b'\xff/0')[1][0:1]
             value = reply.split(b'\x03\r\n')[0].split(b'\xff/0')[1][1:]

--- a/versioneer.py
+++ b/versioneer.py
@@ -339,9 +339,9 @@ def get_config_from_root(root):
     # configparser.NoOptionError (if it lacks "VCS="). See the docstring at
     # the top of versioneer.py for instructions on writing your setup.cfg .
     setup_cfg = os.path.join(root, "setup.cfg")
-    parser = configparser.SafeConfigParser()
+    parser = configparser.ConfigParser()
     with open(setup_cfg, "r") as f:
-        parser.readfp(f)
+        parser.read_file(f)
     VCS = parser.get("versioneer", "VCS")  # mandatory
 
     def get(parser, name):


### PR DESCRIPTION
Fixes #6 

When the read times out for a query and returns `b''`, checking for `''` does't catch it, so it eventually splits the empty bytes and tries to access an index that doesn't exist. Checking for `b''` allows it to properly return the `'no device found'` error.

This also fixes two syntax warnings around checking identities of literals instead of checking for equality: `SyntaxWarning: "is not" with a literal. Did you mean "!="?`